### PR TITLE
Override global `dataset_info` properties when processing CrossDock using only Ca atoms

### DIFF
--- a/process_crossdock.py
+++ b/process_crossdock.py
@@ -256,6 +256,9 @@ if __name__ == '__main__':
     
     if args.ca_only:
         dataset_info = dataset_params['crossdock']
+        amino_acid_dict = dataset_info['aa_encoder']
+        atom_dict = dataset_info['atom_encoder']
+        atom_decoder = dataset_info['atom_decoder']
 
     # Make output directory
     if args.outdir is None:


### PR DESCRIPTION
* Now overriding global `dataset_info` properties when processing CrossDock using only Ca atoms, as otherwise these values would not be updated (i.e., correct) e.g., for `amino_acid_dict` at runtime.
* To my best knowledge, without this change, it is currently not possible to process CrossDock with `ca_only=True`.